### PR TITLE
Update GA script to use config variable

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,12 +27,12 @@ crossorigin="anonymous">
 {% if jekyll.environment == 'production' %}
 <!-- change your GA id in _config.yml -->
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-QS47EGNW5T"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'G-QS47EGNW5T');
+  gtag('config', '{{ site.google_analytics }}');
 </script>
 {% endif %}
 


### PR DESCRIPTION
## Summary
- read Google Analytics ID from `site.google_analytics` in the default layout

## Testing
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ece82bc788329b2cc95ad873f390e