### PR TITLE
Add lang and timezone to config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,8 @@ logo: 'assets/images/logo.png'
 favicon: 'assets/images/logo.png'
 url: "https://journalforwellbeing.com"
 baseurl: "" 
+lang: en-US
+timezone: UTC
 google_analytics: 'G-QS47EGNW5T'
 disqus: 'journalforwellbeing'
 include: ["_pages"]


### PR DESCRIPTION
## Summary
- specify language and timezone for the site

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ece9b490483298b99288f8b516693