### PR TITLE
Add social metadata to config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,15 @@ description: "..."
 logo: 'assets/images/logo.png'
 favicon: 'assets/images/logo.png'
 url: "https://journalforwellbeing.com"
-baseurl: "" 
+baseurl: ""
 lang: en-US
 timezone: UTC
+twitter_username: journalwell
+author: "Journal for Wellbeing"
+social:
+  links:
+    - https://twitter.com/journalwell
+    - https://mastodon.social/@journalwell
 google_analytics: 'G-QS47EGNW5T'
 disqus: 'journalforwellbeing'
 include: ["_pages"]


### PR DESCRIPTION
## Summary
- add `twitter_username`, `author`, and social links in `_config.yml`

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685ed344d00c8329a1520625f3861a11