### PR TITLE
Insert AdSense tag in default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,6 +36,10 @@
 
   <!-- Scripts -->
   <script src="{{ site.baseurl }}/assets/js/jquery.min.js"></script>
+
+  <!-- Google AdSense (global script) -->
+  <script data-ad-client="ca-pub-6236889265406066" async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 </head>
 
 {% if jekyll.environment == 'production' %}


### PR DESCRIPTION
## Summary
- add Google AdSense global script to the default layout head section

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*
- `bundle install --path vendor/bundle` *(fails due to 403 Forbidden - no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6868613bd86883299c2f3064507da1fd