### PR TITLE
Fix SEO and accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Copyright (C) 2019 Sal, https://www.wowthemes.net
 
 **Mediumish for Jekyll** is designed and developed by [Sal](https://www.wowthemes.net) and it is *free* under MIT license. 
 
-<a href="https://www.wowthemes.net/donate/" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a>
+<a href="https://www.wowthemes.net/donate/" target="_blank" rel="noopener noreferrer"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a>
 
 ### Contribute
 

--- a/_includes/featuredbox.html
+++ b/_includes/featuredbox.html
@@ -42,7 +42,7 @@
                                 {% endif %}
                                 </span>
                                 <span class="author-meta">
-                                <span class="post-name"><a target="_blank" href="{{ author.web }}">{{ author.display_name }}</a></span><br/>
+                                <span class="post-name"><a target="_blank" rel="noopener noreferrer" href="{{ author.web }}">{{ author.display_name }}</a></span><br/>
                                 {% endif %}
                                 <span class="post-date">{{ post.date | date_to_string }}</span>
                                 </span>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <title>{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.description %}{{ page.description | strip_html | truncate: 160 }}{% else %}{{ site.description | strip_html | truncate: 160 }}{% endif %}">
 
   <!-- Open Graph -->

--- a/_includes/postbox.html
+++ b/_includes/postbox.html
@@ -38,7 +38,7 @@
                 {% endif %}
                 </span>
                 <span class="author-meta">
-                <span class="post-name"><a target="_blank" href="{{ author.web }}">{{ author.display_name }}</a></span><br/>
+                <span class="post-name"><a target="_blank" rel="noopener noreferrer" href="{{ author.web }}">{{ author.display_name }}</a></span><br/>
                 {% endif %}
                 <span class="post-date">{{ post.date | date_to_string }}</span>
                 </span>

--- a/_includes/share.html
+++ b/_includes/share.html
@@ -4,19 +4,19 @@
     </p>
     <ul>
         <li class="ml-1 mr-1">
-            <a target="_blank" href="https://twitter.com/intent/tweet?text={{ page.title }}&url={{ page.url | absolute_url }}" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
+            <a target="_blank" rel="noopener noreferrer" href="https://twitter.com/intent/tweet?text={{ page.title }}&url={{ page.url | absolute_url }}" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
                 <i class="fab fa-twitter"></i>
             </a>
         </li>
 
         <li class="ml-1 mr-1">
-            <a target="_blank" href="https://facebook.com/sharer.php?u={{ page.url | absolute_url }}" onclick="window.open(this.href, 'facebook-share', 'width=550,height=435');return false;">
+            <a target="_blank" rel="noopener noreferrer" href="https://facebook.com/sharer.php?u={{ page.url | absolute_url }}" onclick="window.open(this.href, 'facebook-share', 'width=550,height=435');return false;">
                 <i class="fab fa-facebook-f"></i>
             </a>
         </li>
 
         <li class="ml-1 mr-1">
-            <a target="_blank" href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url }}" onclick="window.open(this.href, 'width=550,height=435');return false;">
+            <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url }}" onclick="window.open(this.href, 'width=550,height=435');return false;">
                 <i class="fab fa-linkedin-in"></i>
             </a>
         </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,8 +7,7 @@
 
   <link rel="icon" href="{{ site.baseurl }}/assets/images/logo.png">
 
-  <!-- Page Title -->
-  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <!-- Page Title is handled by jekyll-seo-tag -->
 
   <!-- SEO Tags -->
   {% seo %}
@@ -98,7 +97,7 @@
   <div class="site-content">
     <div class="container">
       <div class="mainheading">
-        <h1 class="sitetitle">{{ site.name }}</h1>
+        <div class="sitetitle">{{ site.name }}</div>
         <p class="lead">{{ site.description }}</p>
       </div>
 
@@ -153,7 +152,7 @@
             Copyright © {{ site.time | date: "%Y" }} {{ site.name }}
           </div>
           <div class="col-md-6 col-sm-6 text-center text-lg-right">
-            <a target="_blank" href="https://www.wowthemes.net/mediumish-free-jekyll-template/">Mediumish Jekyll Theme</a> by WowThemes.net
+            <a target="_blank" rel="noopener noreferrer" href="https://www.wowthemes.net/mediumish-free-jekyll-template/">Mediumish Jekyll Theme</a> by WowThemes.net
             &nbsp;|&nbsp;
             <a href="{{ '/privacy-policy/' | relative_url }}">Privacy Policy</a>
           </div>
@@ -174,7 +173,7 @@
   <script src="{{ site.baseurl }}/assets/js/ie10-viewport-bug-workaround.js"></script>
 
   {% if page.layout == 'post' %}
-    <script id="dsq-count-scr" src="//{{site.disqus}}.disqus.com/count.js"></script>
+    <script id="dsq-count-scr" src="https://{{site.disqus}}.disqus.com/count.js"></script>
     {% include article-schema.html %}
   {% endif %}
 </body>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -32,7 +32,7 @@ post_class: post-template
                         {% endif %}
                     </div>
                     <div class="col-xs-12 col-md-9 col-lg-10 text-center text-md-left">
-                        <a target="_blank" class="link-dark" href="{{ author.web }}">{{ author.display_name }}</a><a target="_blank" href="{{ author.twitter }}" class="btn follow">Follow</a>
+                        <a target="_blank" rel="noopener noreferrer" class="link-dark" href="{{ author.web }}">{{ author.display_name }}</a><a target="_blank" rel="noopener noreferrer" href="{{ author.twitter }}" class="btn follow">Follow</a>
                         <span class="author-description">{{ author.description }}</span>
                     </div>
                 </div>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -21,7 +21,7 @@ comments: false
     <p>This project is maintained by someone who journals often and thinks slowly. There’s no personal brand, coaching offer, or productivity funnel — just an interest in the written word and what it reveals.</p>
 
     <h4 class="mt-5">Colophon</h4>
-    <p>This site is built with <a href="https://jekyllrb.com/" target="_blank">Jekyll</a> and uses the <a href="https://github.com/wowthemesnet/mediumish-theme-jekyll" target="_blank">Mediumish theme</a> by <a href="https://www.wowthemes.net" target="_blank">WowThemes</a>, adapted for a softer and quieter feel. It’s hosted with GitHub Pages.</p>
+    <p>This site is built with <a href="https://jekyllrb.com/" target="_blank" rel="noopener noreferrer">Jekyll</a> and uses the <a href="https://github.com/wowthemesnet/mediumish-theme-jekyll" target="_blank" rel="noopener noreferrer">Mediumish theme</a> by <a href="https://www.wowthemes.net" target="_blank" rel="noopener noreferrer">WowThemes</a>, adapted for a softer and quieter feel. It’s hosted with GitHub Pages.</p>
 
     <p class="text-muted small mt-4">© {{ site.time | date: '%Y' }} Journal for Wellbeing. Feel free to quote or share with credit and a link back.</p>
 


### PR DESCRIPTION
## Summary
- update canonical title tag include
- remove duplicate title from default layout
- demote site heading to `<div>` for single H1
- add security rel to external links
- switch Disqus script to https

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68769c5c994c8329ac112b5b7559d79d